### PR TITLE
Add gnome-shell version 3.20.4 to supported versions

### DIFF
--- a/metadata.json
+++ b/metadata.json
@@ -3,6 +3,7 @@
   "description": "Remove the delay of popups like the Alt-Tab switcher.",
   "uuid": "instant-switcher-popups@christopher.luebbemeier.gmail.com",
   "shell-version": [
+    "3.20.4",
     "3.22.3",
     "3.24"
   ],


### PR DESCRIPTION
I compared the show function and discovered it was the same as newer versions. Adding in this version and activating the plugin worked.